### PR TITLE
Modules support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,12 +83,6 @@
     </scm>
 
     <dependencies>
-        <dependency>
-            <groupId>com.github.davidmoten</groupId>
-            <artifactId>guava-mini</artifactId>
-            <version>0.1.2</version>
-        </dependency>
-
         <!-- Test Dependencies -->
         <dependency>
             <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.target>11</maven.compiler.target>
         <scm.url>scm:git:https://github.com/davidmoten/rtree2.git</scm.url>
         <slf4j.version>1.7.12</slf4j.version>
 

--- a/src/main/java/com/github/davidmoten/guavamini/Collections2.java
+++ b/src/main/java/com/github/davidmoten/guavamini/Collections2.java
@@ -1,0 +1,23 @@
+package com.github.davidmoten.guavamini;
+
+import java.util.Collection;
+
+public final class Collections2 {
+
+    private Collections2() {
+        // prevent instantiation
+    }
+
+    /**
+     * Used to avoid http://bugs.sun.com/view_bug.do?bug_id=6558557
+     * 
+     * @param iterable
+     *            input
+     * @param <T>
+     *            generic type of collection
+     * @return input cast as collection
+     */
+    static <T> Collection<T> cast(Iterable<T> iterable) {
+        return (Collection<T>) iterable;
+    }
+}

--- a/src/main/java/com/github/davidmoten/guavamini/Iterators.java
+++ b/src/main/java/com/github/davidmoten/guavamini/Iterators.java
@@ -1,0 +1,36 @@
+package com.github.davidmoten.guavamini;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+public final class Iterators {
+
+    private Iterators() {
+        // prevent instantiation
+    }
+
+    /**
+     * Adds all elements in {@code iterator} to {@code collection}. The iterator
+     * will be left exhausted: its {@code hasNext()} method will return
+     * {@code false}.
+     *
+     * @param addTo
+     *            collection to add to
+     * @param iterator
+     *            iterator whose elements will be added to the collection
+     * @param <T>
+     *            generic type of collection
+     * @return {@code true} if {@code collection} was modified as a result of
+     *         this operation
+     */
+    public static <T> boolean addAll(Collection<T> addTo, Iterator<? extends T> iterator) {
+        com.github.davidmoten.guavamini.Preconditions.checkNotNull(addTo);
+        Preconditions.checkNotNull(iterator);
+        boolean wasModified = false;
+        while (iterator.hasNext()) {
+            wasModified |= addTo.add(iterator.next());
+        }
+        return wasModified;
+    }
+
+}

--- a/src/main/java/com/github/davidmoten/guavamini/Lists.java
+++ b/src/main/java/com/github/davidmoten/guavamini/Lists.java
@@ -1,0 +1,69 @@
+package com.github.davidmoten.guavamini;
+
+import com.github.davidmoten.guavamini.annotations.VisibleForTesting;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+
+public final class Lists {
+
+    private Lists() {
+        // cannot instantiate
+    }
+
+    public static <E> ArrayList<E> newArrayList(E... elements) {
+        com.github.davidmoten.guavamini.Preconditions.checkNotNull(elements);
+        // Avoid integer overflow when a large array is passed in
+        int capacity = computeArrayListCapacity(elements.length);
+        ArrayList<E> list = new ArrayList<E>(capacity);
+        Collections.addAll(list, elements);
+        return list;
+    }
+
+    @VisibleForTesting
+    static int computeArrayListCapacity(int arraySize) {
+        com.github.davidmoten.guavamini.Preconditions.checkArgument(arraySize >= 0, "arraySize must be non-negative");
+
+        // TODO(kevinb): Figure out the right behavior, and document it
+        return saturatedCast(5L + arraySize + (arraySize / 10));
+    }
+
+    /**
+     * Returns the {@code int} nearest in value to {@code value}.
+     *
+     * @param value
+     *            any {@code long} value
+     * @return the same value cast to {@code int} if it is in the range of the
+     *         {@code int} type, {@link Integer#MAX_VALUE} if it is too large,
+     *         or {@link Integer#MIN_VALUE} if it is too small
+     */
+    @VisibleForTesting
+    static int saturatedCast(long value) {
+        if (value > Integer.MAX_VALUE) {
+            return Integer.MAX_VALUE;
+        }
+        if (value < Integer.MIN_VALUE) {
+            return Integer.MIN_VALUE;
+        }
+        return (int) value;
+    }
+
+    public static <E> ArrayList<E> newArrayList() {
+        return new ArrayList<E>();
+    }
+
+    public static <E> ArrayList<E> newArrayList(Iterable<? extends E> elements) {
+        Preconditions.checkNotNull(elements); // for GWT
+        // Let ArrayList's sizing logic work, if possible
+        return (elements instanceof Collection) ? new ArrayList<E>(Collections2.cast(elements))
+                : newArrayList(elements.iterator());
+    }
+
+    public static <E> ArrayList<E> newArrayList(Iterator<? extends E> elements) {
+        ArrayList<E> list = newArrayList();
+        Iterators.addAll(list, elements);
+        return list;
+    }
+}

--- a/src/main/java/com/github/davidmoten/guavamini/Objects.java
+++ b/src/main/java/com/github/davidmoten/guavamini/Objects.java
@@ -1,0 +1,18 @@
+package com.github.davidmoten.guavamini;
+
+import java.util.Arrays;
+
+public final class Objects {
+
+    private Objects() {
+        // prevent instantiation
+    }
+
+    public static int hashCode(Object... objects) {
+        return Arrays.hashCode(objects);
+    }
+
+    public static boolean equal(Object a, Object b) {
+        return a == b || (a != null && a.equals(b));
+    }
+}

--- a/src/main/java/com/github/davidmoten/guavamini/Optional.java
+++ b/src/main/java/com/github/davidmoten/guavamini/Optional.java
@@ -1,0 +1,61 @@
+package com.github.davidmoten.guavamini;
+
+public final class Optional<T> {
+
+    private final T value;
+    private final boolean present;
+
+    private Optional(T value, boolean present) {
+        this.value = value;
+        this.present = present;
+    }
+
+    private Optional() {
+        //no-arg constructor to enable kryo (a bit yukky but not a big deal)
+        this(null, false);
+    }
+
+    public boolean isPresent() {
+        return present;
+    }
+
+    public T get() {
+        if (present)
+            return value;
+        else
+            throw new NotPresentException();
+    }
+
+    public T or(T alternative) {
+        if (present)
+            return value;
+        else
+            return alternative;
+    }
+
+    public static <T> Optional<T> fromNullable(T t) {
+        if (t == null)
+            return Optional.absent();
+        else
+            return Optional.of(t);
+    }
+
+    public static <T> Optional<T> of(T t) {
+        return new Optional<T>(t, true);
+    }
+
+    public static <T> Optional<T> absent() {
+        return new Optional<T>();
+    }
+
+    public static class NotPresentException extends RuntimeException {
+
+        private static final long serialVersionUID = -4444814681271790328L;
+
+    }
+
+    @Override
+    public String toString() {
+        return present ? String.format("Optional.of(%s)", value) : "Optional.absent";
+    }
+}

--- a/src/main/java/com/github/davidmoten/guavamini/Preconditions.java
+++ b/src/main/java/com/github/davidmoten/guavamini/Preconditions.java
@@ -1,0 +1,29 @@
+package com.github.davidmoten.guavamini;
+
+public final class Preconditions {
+
+    private Preconditions() {
+        // prevent instantiation
+    }
+
+    public static <T> T checkNotNull(T t) {
+        return checkNotNull(t, null);
+    }
+
+    public static <T> T checkNotNull(T t, String message) {
+        if (t == null)
+            throw new NullPointerException(message);
+        return t;
+    }
+
+    public static void checkArgument(boolean b, String message) {
+        if (!b)
+            throw new IllegalArgumentException(message);
+    }
+
+    public static void checkArgument(boolean b) {
+        if (!b)
+            throw new IllegalArgumentException();
+    }
+
+}

--- a/src/main/java/com/github/davidmoten/guavamini/Sets.java
+++ b/src/main/java/com/github/davidmoten/guavamini/Sets.java
@@ -1,0 +1,69 @@
+package com.github.davidmoten.guavamini;
+
+import com.github.davidmoten.guavamini.annotations.VisibleForTesting;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+
+public final class Sets {
+
+    private Sets() {
+        // prevent instantiation
+    }
+
+    static final int MAX_POWER_OF_TWO = 1 << (Integer.SIZE - 2);
+
+    public static <E> HashSet<E> newHashSet(E... elements) {
+        Preconditions.checkNotNull(elements);
+        HashSet<E> set = newHashSetWithExpectedSize(elements.length);
+        Collections.addAll(set, elements);
+        return set;
+    }
+
+    public static <E> HashSet<E> newHashSetWithExpectedSize(int expectedSize) {
+        return new HashSet<E>(capacity(expectedSize));
+    }
+
+    /**
+     * Returns a capacity that is sufficient to keep the map from being resized
+     * as long as it grows no larger than expectedSize and the load factor is >=
+     * its default (0.75).
+     */
+    @VisibleForTesting
+    static int capacity(int expectedSize) {
+        if (expectedSize < 3) {
+            checkNonnegative(expectedSize, "expectedSize");
+            return expectedSize + 1;
+        }
+        if (expectedSize < MAX_POWER_OF_TWO) {
+            return expectedSize + expectedSize / 3;
+        }
+        return Integer.MAX_VALUE; // any large value
+    }
+
+    @VisibleForTesting
+    static int checkNonnegative(int value, String name) {
+        if (value < 0) {
+            throw new IllegalArgumentException(name + " cannot be negative but was: " + value);
+        }
+        return value;
+    }
+
+    public static <E> HashSet<E> newHashSet(Iterable<? extends E> elements) {
+        return (elements instanceof Collection) ? new HashSet<E>(Collections2.cast(elements))
+                : newHashSet(elements.iterator());
+    }
+
+    public static <E> HashSet<E> newHashSet(Iterator<? extends E> elements) {
+        HashSet<E> set = newHashSet();
+        Iterators.addAll(set, elements);
+        return set;
+    }
+
+    public static <E> HashSet<E> newHashSet() {
+        return new HashSet<E>();
+    }
+
+}

--- a/src/main/java/com/github/davidmoten/guavamini/annotations/VisibleForTesting.java
+++ b/src/main/java/com/github/davidmoten/guavamini/annotations/VisibleForTesting.java
@@ -1,0 +1,8 @@
+package com.github.davidmoten.guavamini.annotations;
+
+/**
+ * Annotates a program element that exists, or is more widely visible than
+ * otherwise necessary, only for use in test code.
+ */
+public @interface VisibleForTesting {
+}

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,7 @@
+module com.github.davidmoten.rtree2 {
+    requires java.desktop;
+
+    exports com.github.davidmoten.guavamini;
+    exports com.github.davidmoten.rtree2;
+    exports com.github.davidmoten.rtree2.geometry;
+}


### PR DESCRIPTION
This changes actually allow to use rtree2 in modular project in conjunction with jlink (since jlink doesn't accept unnamed modules, i.e. without `module-info.java`).

As for convenience, i transferred guava-mini project files to rtree2 itself. In such case it is easier to expose this project as a dedicated self-sufficient module. I hope this does not break your code-conventions.