### PR TITLE
Removes a java.awt dependency

### DIFF
--- a/src/main/java/com/github/davidmoten/rtree2/internal/Line2D.java
+++ b/src/main/java/com/github/davidmoten/rtree2/internal/Line2D.java
@@ -200,8 +200,8 @@ public final class Line2D {
      *         otherwise.
      * @since 1.2
      */
-    private static boolean linesIntersect(double x1, double y1, double x2, double y2, double x3,
-            double y3, double x4, double y4) {
+    static boolean linesIntersect(double x1, double y1, double x2, double y2, double x3,
+                                  double y3, double x4, double y4) {
         return ((relativeCCW(x1, y1, x2, y2, x3, y3) * relativeCCW(x1, y1, x2, y2, x4, y4) <= 0)
                 && (relativeCCW(x3, y3, x4, y4, x1, y1)
                         * relativeCCW(x3, y3, x4, y4, x2, y2) <= 0));

--- a/src/main/java/com/github/davidmoten/rtree2/internal/RectangleUtil.java
+++ b/src/main/java/com/github/davidmoten/rtree2/internal/RectangleUtil.java
@@ -1,7 +1,5 @@
 package com.github.davidmoten.rtree2.internal;
 
-import java.awt.geom.Line2D;
-
 public final class RectangleUtil {
 
     private RectangleUtil() {
@@ -43,7 +41,7 @@ public final class RectangleUtil {
     public static boolean rectangleIntersectsLine(double rectX, double rectY, double rectWidth, double rectHeight,
             double x1, double y1, double x2, double y2) {
         return _rectangleIntersectsLine(rectX, rectY, rectWidth, rectHeight, x1, y1, x2, y2)
-                || Line2D.Double.linesIntersect(rectX, rectY, rectX + rectWidth, rectY + rectHeight, x1, y1, x2, y2);
+                || Line2D.linesIntersect(rectX, rectY, rectX + rectWidth, rectY + rectHeight, x1, y1, x2, y2);
     }
     
     private static boolean _rectangleIntersectsLine(double rectX, double rectY, double rectWidth,


### PR DESCRIPTION
There was a dependency to java.awt.Line2D in RectangleUtil.java. This commit replaces this with the project version Line2D.java to make it work on Android.